### PR TITLE
Add check for widget existence before accessing keys

### DIFF
--- a/src/reskinner/elements.py
+++ b/src/reskinner/elements.py
@@ -130,7 +130,7 @@ class ElementReskinner:
         ):
             self._parent_row_frame(element.ParentRowFrame, {"background": "BACKGROUND"})
 
-        if "background" in element.widget.keys() and element.widget.cget("background"):
+        if element.widget and "background" in element.widget.keys() and element.widget.cget("background"):
             self.colorizer.element(element, {"background": "BACKGROUND"})
 
     def _handle_right_click_menus(self, element: sg.Element) -> None:


### PR DESCRIPTION
Using https://docs.pysimplegui.com/en/latest/documentation/module/dynamic_layouts/ as example for dynamic layouts, when adding a new row, reskinner would fail with:
```
Traceback (most recent call last):
  File "C:\GIT\project\gui\extend_layout.py", line 75, in <module>
    main()
  File "C:\GIT\project\gui\extend_layout.py", line 69, in main
    reskin_job(window, CURRENT_THEME)
  File "c:\git\project\gui\ttk_theme.py", line 85, in reskin_job
    reskin(
  File "C:\GIT\project\venv\Lib\site-packages\reskinner\reskinner.py", line 134, in reskin
    _reskin(colorizer, window, element_filter, reskin_background)
  File "C:\GIT\project\venv\Lib\site-packages\reskinner\reskinner.py", line 173, in _reskin
    element_reskinner.reskin_element(element)
  File "C:\GIT\project\venv\Lib\site-packages\reskinner\elements.py", line 162, in reskin_element
    self._dispatcher.dispatch(element)
  File "C:\GIT\project\venv\Lib\site-packages\reskinner\elements.py", line 38, in dispatch
    handler(element)
  File "C:\GIT\project\venv\Lib\site-packages\reskinner\elements.py", line 126, in _handle_generic_tweaks
    if "background" in element.widget.keys() and element.widget.cget("background"):
                       ^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'keys'
```

With this patch, extended layouts work and get reskinned properly.