### PR TITLE
Restore Python 3.8 compatibility

### DIFF
--- a/src/reskinner/colorizer.py
+++ b/src/reskinner/colorizer.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from functools import lru_cache
 from tkinter import Widget
 from tkinter.ttk import Style
-from typing import Any, Callable, Dict, Optional, Tuple, TypeVar, Union
+from typing import Any, Callable, Dict, Optional, Tuple, TypeVar, Union, List
 
 from colour import Color
 
@@ -21,7 +21,7 @@ ThemeDict = (
     Union[
         Dict[str, Union[str, Tuple[str, str], int]],
         Dict[str, Union[str, int]],
-        Dict[str, Union[str, Tuple[str, str], int, list[str]]],
+        Dict[str, Union[str, Tuple[str, str], int, List[str]]],
     ],
 )
 ThemeDictColorKey = Union[str, Tuple[str, int]]

--- a/src/reskinner/elements.py
+++ b/src/reskinner/elements.py
@@ -2,7 +2,7 @@ from functools import partial
 from tkinter import Frame as TKFrame
 from tkinter import Menu as TKMenu, Canvas as TKCanvas
 from tkinter.ttk import Widget as TTKWidget
-from typing import Callable, Dict, List, Tuple, Type, Union
+from typing import Callable, Dict, List, Tuple, Type, Union, Optional
 
 from .colorizer import (
     Colorizer,
@@ -63,7 +63,7 @@ class ElementDispatcher:
 class ElementReskinner:
     colorizer: Colorizer
 
-    def __init__(self, colorizer: Colorizer | None = None):
+    def __init__(self, colorizer: Optional[Colorizer] = None):
         """
         Initializes an ElementReskinner instance.
 
@@ -249,7 +249,7 @@ class ElementReskinner:
         if not element.widget:
             return
 
-        def _configure_child(child: TKFrame | TKCanvas):
+        def _configure_child(child: Union[TKFrame, TKCanvas]):
             self.colorizer.configure(
                 {"background": "BACKGROUND", "highlightbackground": "BACKGROUND"},
                 child.configure,


### PR DESCRIPTION
Hi,

While I know Python 3.8 is EOL, I do have some legacy builds of my software for elder systems.
I noticed that Python 3.8 no longers runs reskinner because of basic typing annotations.
Restored compatibility.